### PR TITLE
Fix/force manager historical alerts

### DIFF
--- a/.github/workflows/dependency-force-manager.yml
+++ b/.github/workflows/dependency-force-manager.yml
@@ -99,10 +99,16 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_PAT != '' && secrets.GH_PAT || github.token }}
         run: |
-          curl -sS \
+          # Fetch ALL alerts regardless of state (open, dismissed, auto_dismissed, fixed).
+          # Historical alerts are used by determine-removable to prevent force-rule oscillation:
+          # Dependabot auto-dismisses alerts when a force is added, so checking only "open"
+          # alerts causes the force to be removed on the next run, reopening the alert.
+          # gh api --paginate follows Link headers automatically across all pages.
+          gh api \
+            --paginate \
             -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer $GH_TOKEN" \
-            "https://api.github.com/repos/${GITHUB_REPOSITORY}/dependabot/alerts?state=open&per_page=100" \
+            "repos/${GITHUB_REPOSITORY}/dependabot/alerts?per_page=100" \
+            | jq -s '[.[][]]' \
             > /tmp/dependabot-alerts.json
 
       - name: Determine removable forces

--- a/.github/workflows/dependency-force-manager.yml
+++ b/.github/workflows/dependency-force-manager.yml
@@ -47,6 +47,7 @@ jobs:
       )
     env:
       DEPENDENCY_FORCE_CONFIGS: githubApi101DebugRuntimeClasspath,githubLegacyDebugRuntimeClasspath,playApi101DebugRuntimeClasspath,playLegacyDebugRuntimeClasspath,githubApi101ReleaseRuntimeClasspath,githubLegacyReleaseRuntimeClasspath,playApi101ReleaseRuntimeClasspath,playLegacyReleaseRuntimeClasspath
+      DEPENDENCY_FORCE_HISTORICAL_ALERT_COOLDOWN_HOURS: 168
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -100,9 +101,11 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_PAT != '' && secrets.GH_PAT || github.token }}
         run: |
           # Fetch ALL alerts regardless of state (open, dismissed, auto_dismissed, fixed).
-          # Historical alerts are used by determine-removable to prevent force-rule oscillation:
-          # Dependabot auto-dismisses alerts when a force is added, so checking only "open"
-          # alerts causes the force to be removed on the next run, reopening the alert.
+          # Historical alerts are used by determine-removable as a cooldown signal:
+          # Dependabot may auto-dismiss alerts immediately after a force is added, so checking
+          # only "open" alerts can remove the force too early and reopen the alert on the next run.
+          # We therefore keep recent historical alerts long enough for the dependency graph to settle,
+          # but still allow automatic removal after the cooldown and safety checks pass.
           # gh api --paginate follows Link headers automatically across all pages.
           gh api \
             --paginate \
@@ -120,6 +123,7 @@ jobs:
             --forced-json /tmp/forced.json \
             --natural-json /tmp/natural.json \
             --alerts-json /tmp/dependabot-alerts.json \
+            --historical-alert-cooldown-hours "$DEPENDENCY_FORCE_HISTORICAL_ALERT_COOLDOWN_HOURS" \
             --output /tmp/removable.json
           count=$(python3 - <<'PY'
           import json

--- a/scripts/manage_dependency_forces.py
+++ b/scripts/manage_dependency_forces.py
@@ -4,13 +4,35 @@ Design philosophy (conservative removal strategy):
     A force rule may only be REMOVED if ALL of the following conditions are met:
       1. The natural (un-forced) resolved version already equals the forced version
          in every Gradle configuration checked (i.e. the force is redundant).
-      2. There is NO currently open Dependabot alert for that dependency.
+      2. The dependency has NEVER had a Dependabot alert in any state.
       3. The GitHub Advisory Database confirms that the natural version is NOT
          within any known vulnerable version range for that package (ecosystem=MAVEN),
          meaning Dependabot would NOT re-open an alert if the force were dropped.
     If ANY condition fails — or if any network/API call errors out — the force is
     kept. This conservative default prevents the ADD/REMOVE oscillation described in:
     https://app.stilla.ai/m/memo_01kq6zw9k3f2199jtez41bzxqh
+
+Why historical alerts (any state) instead of only open alerts?
+
+    Dependabot alerts get automatically dismissed/closed when a force rule is
+    added that pins to a patched version. If we only check open alerts, the
+    condition will always be False right after the force was added, and we
+    will incorrectly delete the force, causing Dependabot to reopen the alert,
+    causing automation to add the force back — the ADD/REMOVE oscillation.
+
+    By checking *historical* alerts (any state, including dismissed, auto_dismissed,
+    fixed), we ensure that once a dependency has been flagged as vulnerable, its
+    force rule is never automatically removed. Removal becomes an explicit human
+    decision, made when the upstream POM no longer declares vulnerable versions of
+    the dependency.
+
+Why tristate (True / False / None) for _version_in_range?
+
+    The original bool-returning implementation silently returned False on any
+    parse failure (ImportError, malformed range, unknown operator). False is
+    interpreted as "version NOT in vulnerable range → safe to remove", which is
+    the opposite of what we want when we cannot determine safety. The tristate
+    design makes parse errors explicit: callers treat None as "unsafe to remove".
 """
 
 from __future__ import annotations
@@ -333,8 +355,12 @@ def _parse_maven_version(version_str: str) -> Any:
         return version_str
 
 
-def _version_in_range(version_str: str, vulnerable_range: str) -> bool:
-    """Return True if *version_str* falls within *vulnerable_range*.
+def _version_in_range(version_str: str, vulnerable_range: str) -> bool | None:
+    """Return True if *version_str* is in *vulnerable_range*, False if definitely not,
+    or None if the result cannot be determined (parse failure, unknown operator, etc.).
+
+    Callers MUST treat None as "unsafe to remove" — it must NOT be silently
+    interpreted as "not in range" (which was the bug in the previous implementation).
 
     Range format examples (GitHub Advisory Database):
       ``>= 4.1.0, < 4.1.118.Final``
@@ -346,25 +372,30 @@ def _version_in_range(version_str: str, vulnerable_range: str) -> bool:
         from packaging.version import Version
 
         if not isinstance(ver, Version):
-            return False  # can't compare safely → caller treats False as uncertain
+            return None  # version_str could not be parsed → undetermined
     except ImportError:
-        return False
+        return None  # packaging library not available → undetermined
 
     for clause in vulnerable_range.split(","):
         clause = clause.strip()
+        if not clause:
+            continue
         m = re.match(r"([><=!]+)\s*(.+)", clause)
         if not m:
-            continue
+            return None  # malformed clause → undetermined
+
         op, bound_str = m.group(1), m.group(2).strip()
         bound = _parse_maven_version(bound_str)
         try:
             from packaging.version import Version
 
             if not isinstance(bound, Version):
-                return False
+                return None  # bound could not be parsed → undetermined
         except ImportError:
-            return False
+            return None
 
+        # Each clause constrains membership: if the version fails ANY clause the
+        # version is definitely outside the range (return False).
         if op == ">=" and not (ver >= bound):
             return False
         elif op == ">" and not (ver > bound):
@@ -377,14 +408,22 @@ def _version_in_range(version_str: str, vulnerable_range: str) -> bool:
             return False
         elif op == "!=" and not (ver != bound):
             return False
+        elif op not in (">=", ">", "<=", "<", "=", "==", "!="):
+            return None  # unknown operator → undetermined
+
+    # All clauses satisfied → version is within the range
     return True
 
 
-def _has_open_alert(dep: str, alerts: list[dict[str, Any]]) -> bool:
-    """Return True if there is at least one OPEN Dependabot alert for *dep* (``group:artifact``)."""
+def _has_any_historical_alert(dep: str, alerts: list[dict[str, Any]]) -> bool:
+    """Return True if *dep* (``group:artifact``) has EVER had a Dependabot alert
+    in ANY state (open, dismissed, auto_dismissed, fixed, …).
+
+    Once a dependency has triggered a Dependabot alert, automation must never
+    auto-remove its force rule. Only a human decision — after verifying the upstream
+    POM no longer declares vulnerable versions — should clear the force.
+    """
     for alert in alerts:
-        if alert.get("state", "").lower() != "open":
-            continue
         pkg = alert.get("dependency", {}).get("package", {})
         if pkg.get("ecosystem", "").lower() == "maven" and pkg.get("name") == dep:
             return True
@@ -467,15 +506,18 @@ def is_safe_to_remove(
 
     Conditions (ALL must hold):
       1. *natural_version* is truthy (caller already verified ``natural == forced``).
-      2. No open Dependabot alert for *dep*.
+      2. The dependency has never had a Dependabot alert in any state.
       3. (If *check_advisories*) The natural version does not fall within any
          known advisory's ``vulnerableVersionRange`` (GitHub Advisory Database).
 
     On any uncertainty or error, returns False (conservative default).
     """
-    # Condition 2: no open alert
-    if _has_open_alert(dep, alerts):
-        print(f"  INFO: skipping removal of {dep} — open Dependabot alert exists")
+    # Condition 2: no historical alert in any state
+    if _has_any_historical_alert(dep, alerts):
+        print(
+            f"  INFO: skipping removal of {dep} — "
+            "dependency has historical Dependabot alerts (any state)"
+        )
         return False
 
     # Condition 3: advisory check via GitHub GraphQL
@@ -497,13 +539,25 @@ def is_safe_to_remove(
             return False
         for adv in advisories:
             vrange = adv.get("vulnerableVersionRange") or ""
-            if vrange and _version_in_range(natural_version, vrange):
+            if not vrange:
+                continue
+            result = _version_in_range(natural_version, vrange)
+            if result is True:
                 first_patched = (adv.get("firstPatchedVersion") or {}).get("identifier", "unknown")
                 print(
                     f"  INFO: skipping removal of {dep}@{natural_version} — "
-                    f"falls in advisory range '{vrange}' (first patched: {first_patched})"
+                    f"natural version matches advisory range '{vrange}' "
+                    f"(first patched: {first_patched})"
                 )
                 return False
+            if result is None:
+                print(
+                    f"  INFO: skipping removal of {dep} — "
+                    f"advisory range '{vrange}' could not be evaluated; treating as unsafe"
+                )
+                return False
+            # result is False: version is definitively NOT in this advisory's range;
+            # continue checking remaining advisories.
 
     return True
 
@@ -538,7 +592,7 @@ def command_determine_removable(args: argparse.Namespace) -> None:
 
         natural_version = successful[0]  # All equal at this point
 
-        # Conditions 2 & 3: open alert check + advisory check
+        # Conditions 2 & 3: historical alert check + advisory check
         if not is_safe_to_remove(
             dep,
             natural_version,

--- a/scripts/manage_dependency_forces.py
+++ b/scripts/manage_dependency_forces.py
@@ -2,29 +2,30 @@
 
 Design philosophy (conservative removal strategy):
     A force rule may only be REMOVED if ALL of the following conditions are met:
-      1. The natural (un-forced) resolved version already equals the forced version
-         in every Gradle configuration checked (i.e. the force is redundant).
-      2. The dependency has NEVER had a Dependabot alert in any state.
-      3. The GitHub Advisory Database confirms that the natural version is NOT
+      1. All successful natural (un-forced) resolutions converge to the same
+         version across the checked Gradle configurations.
+      2. That natural version is not older than the forced version, and not older
+         than any known patched baseline from Dependabot alert history.
+      3. The dependency has no CURRENT open Dependabot alert.
+      4. If the dependency had historical alerts, the latest resolved alert is
+         older than the configured cooldown window.
+      5. The GitHub Advisory Database confirms that the natural version is NOT
          within any known vulnerable version range for that package (ecosystem=MAVEN),
-         meaning Dependabot would NOT re-open an alert if the force were dropped.
+         meaning Dependabot should not re-open an alert if the force were dropped.
     If ANY condition fails — or if any network/API call errors out — the force is
     kept. This conservative default prevents the ADD/REMOVE oscillation described in:
     https://app.stilla.ai/m/memo_01kq6zw9k3f2199jtez41bzxqh
 
-Why historical alerts (any state) instead of only open alerts?
+Why historical alerts plus cooldown instead of "ever alerted => never remove"?
 
-    Dependabot alerts get automatically dismissed/closed when a force rule is
-    added that pins to a patched version. If we only check open alerts, the
-    condition will always be False right after the force was added, and we
-    will incorrectly delete the force, causing Dependabot to reopen the alert,
-    causing automation to add the force back — the ADD/REMOVE oscillation.
+    Dependabot alerts often close automatically right after a force rule pins a
+    patched version. If we only check "open" alerts, the next run may wrongly
+    conclude the force is removable, reopen the alert, and start oscillating.
 
-    By checking *historical* alerts (any state, including dismissed, auto_dismissed,
-    fixed), we ensure that once a dependency has been flagged as vulnerable, its
-    force rule is never automatically removed. Removal becomes an explicit human
-    decision, made when the upstream POM no longer declares vulnerable versions of
-    the dependency.
+    Historical alerts are therefore treated as a stabilization signal, but not a
+    permanent blacklist. Once the dependency has stayed resolved long enough and
+    the natural version remains at or above the patched baseline, automation may
+    remove the force again.
 
 Why tristate (True / False / None) for _version_in_range?
 
@@ -44,6 +45,7 @@ import re
 import subprocess
 import urllib.error
 import urllib.request
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
@@ -51,6 +53,7 @@ import tomllib
 
 AUTO_FORCE_BEGIN = "            // BEGIN AUTO FORCED DEPENDENCIES (managed by workflow)"
 AUTO_FORCE_END = "            // END AUTO FORCED DEPENDENCIES (managed by workflow)"
+DEFAULT_HISTORICAL_ALERT_COOLDOWN_HOURS = 24 * 7
 
 
 def load_catalog(toml_path: Path) -> tuple[dict[str, Any], dict[str, Any]]:
@@ -150,6 +153,10 @@ def version_key(version: str) -> list[tuple[int, int | str]]:
         else:
             key.append((1, part.lower()))
     return key
+
+
+def version_gte(left: str, right: str) -> bool:
+    return version_key(left) >= version_key(right)
 
 
 def command_read_forces(args: argparse.Namespace) -> None:
@@ -333,6 +340,75 @@ def line_dep(expr: str, versions: dict[str, Any], libraries: dict[str, Any]) -> 
 # ---------------------------------------------------------------------------
 
 
+def _parse_github_timestamp(raw: str | None) -> datetime | None:
+    if not raw:
+        return None
+    try:
+        return datetime.fromisoformat(raw.replace("Z", "+00:00")).astimezone(timezone.utc)
+    except ValueError:
+        return None
+
+
+def _alert_resolution_timestamp(alert: dict[str, Any]) -> datetime | None:
+    for field in ("fixed_at", "dismissed_at", "auto_dismissed_at", "updated_at", "created_at"):
+        timestamp = _parse_github_timestamp(alert.get(field))
+        if timestamp is not None:
+            return timestamp
+    return None
+
+
+def _iter_dep_alerts(dep: str, alerts: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    matched: list[dict[str, Any]] = []
+    for alert in alerts:
+        pkg = alert.get("dependency", {}).get("package", {})
+        if pkg.get("ecosystem", "").lower() == "maven" and pkg.get("name") == dep:
+            matched.append(alert)
+    return matched
+
+
+def _has_open_alert(dep: str, alerts: list[dict[str, Any]]) -> bool:
+    return any((alert.get("state") or "").lower() == "open" for alert in _iter_dep_alerts(dep, alerts))
+
+
+def _latest_resolved_alert_timestamp(dep: str, alerts: list[dict[str, Any]]) -> datetime | None:
+    timestamps = [
+        timestamp
+        for alert in _iter_dep_alerts(dep, alerts)
+        if (alert.get("state") or "").lower() != "open"
+        for timestamp in [_alert_resolution_timestamp(alert)]
+        if timestamp is not None
+    ]
+    return max(timestamps) if timestamps else None
+
+
+def _patched_baseline(dep: str, alerts: list[dict[str, Any]]) -> str | None:
+    baseline: str | None = None
+    for alert in _iter_dep_alerts(dep, alerts):
+        patched = (
+            (alert.get("security_vulnerability") or {}).get("first_patched_version") or {}
+        ).get("identifier") or (
+            (alert.get("security_vulnerability") or {}).get("first_patched_version") or {}
+        ).get("version")
+        if not patched:
+            continue
+        if baseline is None or version_gte(patched, baseline):
+            baseline = patched
+    return baseline
+
+
+def _cooldown_elapsed(
+    dep: str,
+    alerts: list[dict[str, Any]],
+    cooldown_hours: int,
+    now: datetime | None = None,
+) -> bool:
+    latest_resolved = _latest_resolved_alert_timestamp(dep, alerts)
+    if latest_resolved is None:
+        return True
+    current = now or datetime.now(timezone.utc)
+    return current - latest_resolved >= timedelta(hours=cooldown_hours)
+
+
 def _parse_maven_version(version_str: str) -> Any:
     """Parse a Maven version string into a comparable object.
 
@@ -415,21 +491,6 @@ def _version_in_range(version_str: str, vulnerable_range: str) -> bool | None:
     return True
 
 
-def _has_any_historical_alert(dep: str, alerts: list[dict[str, Any]]) -> bool:
-    """Return True if *dep* (``group:artifact``) has EVER had a Dependabot alert
-    in ANY state (open, dismissed, auto_dismissed, fixed, …).
-
-    Once a dependency has triggered a Dependabot alert, automation must never
-    auto-remove its force rule. Only a human decision — after verifying the upstream
-    POM no longer declares vulnerable versions — should clear the force.
-    """
-    for alert in alerts:
-        pkg = alert.get("dependency", {}).get("package", {})
-        if pkg.get("ecosystem", "").lower() == "maven" and pkg.get("name") == dep:
-            return True
-    return False
-
-
 def _query_advisories_for_dep(group: str, artifact: str, gh_token: str) -> list[dict[str, Any]] | None:
     """Query GitHub GraphQL for all security advisories affecting ``group:artifact`` (MAVEN).
 
@@ -498,29 +559,58 @@ query($after: String) {
 def is_safe_to_remove(
     dep: str,
     natural_version: str,
+    forced_version: str,
     alerts: list[dict[str, Any]],
+    cooldown_hours: int,
     check_advisories: bool = True,
     gh_token: str | None = None,
+    now: datetime | None = None,
 ) -> bool:
     """Return True only if it is safe to remove the force rule for *dep*.
 
     Conditions (ALL must hold):
-      1. *natural_version* is truthy (caller already verified ``natural == forced``).
-      2. The dependency has never had a Dependabot alert in any state.
-      3. (If *check_advisories*) The natural version does not fall within any
+      1. *natural_version* is truthy and not older than the forced version.
+      2. The dependency has no open Dependabot alert.
+      3. If the dependency has historical resolved alerts, the configured cooldown
+         period has elapsed since the latest resolution/dismissal.
+      4. The natural version is not older than the strongest patched baseline seen
+         in alert history.
+      5. (If *check_advisories*) The natural version does not fall within any
          known advisory's ``vulnerableVersionRange`` (GitHub Advisory Database).
 
     On any uncertainty or error, returns False (conservative default).
     """
-    # Condition 2: no historical alert in any state
-    if _has_any_historical_alert(dep, alerts):
+    if not natural_version:
+        print(f"  INFO: skipping removal of {dep} — natural version missing")
+        return False
+
+    if not version_gte(natural_version, forced_version):
         print(
             f"  INFO: skipping removal of {dep} — "
-            "dependency has historical Dependabot alerts (any state)"
+            f"natural version {natural_version} is older than forced {forced_version}"
         )
         return False
 
-    # Condition 3: advisory check via GitHub GraphQL
+    if _has_open_alert(dep, alerts):
+        print(f"  INFO: skipping removal of {dep} — dependency still has an open Dependabot alert")
+        return False
+
+    if not _cooldown_elapsed(dep, alerts, cooldown_hours, now=now):
+        latest_resolved = _latest_resolved_alert_timestamp(dep, alerts)
+        print(
+            f"  INFO: skipping removal of {dep} — "
+            f"historical alert cooldown still active since {latest_resolved.isoformat() if latest_resolved else 'unknown'}"
+        )
+        return False
+
+    patched_baseline = _patched_baseline(dep, alerts)
+    if patched_baseline and not version_gte(natural_version, patched_baseline):
+        print(
+            f"  INFO: skipping removal of {dep} — "
+            f"natural version {natural_version} is below patched baseline {patched_baseline}"
+        )
+        return False
+
     if check_advisories:
         if not gh_token:
             print(
@@ -578,25 +668,32 @@ def command_determine_removable(args: argparse.Namespace) -> None:
             if not entry.get("config_missing") and entry.get("resolved")
         ]
 
-        # Condition 1: natural version must equal forced version in all configs
         if not successful:
             print(f"  INFO: skipping removal of {dep} — no successful natural resolution found")
             continue
-        if not all(version == item["version"] for version in successful):
-            natural_versions = sorted(set(successful))
+        natural_versions = sorted(set(successful), key=version_key)
+        if len(natural_versions) != 1:
             print(
                 f"  INFO: skipping removal of {dep} — "
-                f"natural version(s) {natural_versions} != forced {item['version']}"
+                f"natural versions diverge across configs: {natural_versions}"
             )
             continue
 
-        natural_version = successful[0]  # All equal at this point
+        natural_version = natural_versions[0]
+        if not version_gte(natural_version, item["version"]):
+            natural_versions = sorted(set(successful))
+            print(
+                f"  INFO: skipping removal of {dep} — "
+                f"natural version {natural_version} is below forced {item['version']}"
+            )
+            continue
 
-        # Conditions 2 & 3: historical alert check + advisory check
         if not is_safe_to_remove(
             dep,
             natural_version,
+            item["version"],
             alerts,
+            cooldown_hours=args.historical_alert_cooldown_hours,
             check_advisories=args.check_advisories,
             gh_token=gh_token,
         ):
@@ -701,6 +798,15 @@ def build_parser() -> argparse.ArgumentParser:
         "--repo",
         default="",
         help="OWNER/REPO (informational; token is read from GH_TOKEN env var)",
+    )
+    determine_removable.add_argument(
+        "--historical-alert-cooldown-hours",
+        type=int,
+        default=DEFAULT_HISTORICAL_ALERT_COOLDOWN_HOURS,
+        help=(
+            "Require this many hours to pass since the latest resolved/dismissed "
+            "historical alert before a force rule may be auto-removed"
+        ),
     )
     determine_removable.add_argument(
         "--check-advisories",

--- a/scripts/manage_dependency_forces.py
+++ b/scripts/manage_dependency_forces.py
@@ -51,6 +51,12 @@ from typing import Any
 
 import tomllib
 
+try:
+    from packaging.version import InvalidVersion, Version
+except ImportError:
+    InvalidVersion = None
+    Version = None
+
 AUTO_FORCE_BEGIN = "            // BEGIN AUTO FORCED DEPENDENCIES (managed by workflow)"
 AUTO_FORCE_END = "            // END AUTO FORCED DEPENDENCIES (managed by workflow)"
 DEFAULT_HISTORICAL_ALERT_COOLDOWN_HOURS = 24 * 7
@@ -255,6 +261,7 @@ def command_resolve_alert_natural(args: argparse.Namespace) -> None:
         {
             alert.get("dependency", {}).get("package", {}).get("name")
             for alert in alerts
+            if _is_open_alert(alert)
             if alert.get("dependency", {}).get("package", {}).get("ecosystem") == "maven"
             and ":" in (alert.get("dependency", {}).get("package", {}).get("name") or "")
         }
@@ -366,8 +373,12 @@ def _iter_dep_alerts(dep: str, alerts: list[dict[str, Any]]) -> list[dict[str, A
     return matched
 
 
+def _is_open_alert(alert: dict[str, Any]) -> bool:
+    return (alert.get("state") or "").lower() == "open"
+
+
 def _has_open_alert(dep: str, alerts: list[dict[str, Any]]) -> bool:
-    return any((alert.get("state") or "").lower() == "open" for alert in _iter_dep_alerts(dep, alerts))
+    return any(_is_open_alert(alert) for alert in _iter_dep_alerts(dep, alerts))
 
 
 def _latest_resolved_alert_timestamp(dep: str, alerts: list[dict[str, Any]]) -> datetime | None:
@@ -416,9 +427,7 @@ def _parse_maven_version(version_str: str) -> Any:
     so that ``packaging.version.parse`` (PEP 440) can handle them.
     Falls back to the raw string if parsing fails.
     """
-    try:
-        from packaging.version import InvalidVersion, Version
-    except ImportError:
+    if Version is None or InvalidVersion is None:
         return version_str
 
     # Strip common Maven suffixes that PEP-440 doesn't understand
@@ -444,13 +453,12 @@ def _version_in_range(version_str: str, vulnerable_range: str) -> bool | None:
       ``>= 0``
     """
     ver = _parse_maven_version(version_str)
-    try:
-        from packaging.version import Version
-
-        if not isinstance(ver, Version):
-            return None  # version_str could not be parsed → undetermined
-    except ImportError:
+    if Version is None:
         return None  # packaging library not available → undetermined
+    if not isinstance(ver, Version):
+        return None  # version_str could not be parsed → undetermined
+
+    saw_valid_clause = False
 
     for clause in vulnerable_range.split(","):
         clause = clause.strip()
@@ -462,13 +470,9 @@ def _version_in_range(version_str: str, vulnerable_range: str) -> bool | None:
 
         op, bound_str = m.group(1), m.group(2).strip()
         bound = _parse_maven_version(bound_str)
-        try:
-            from packaging.version import Version
-
-            if not isinstance(bound, Version):
-                return None  # bound could not be parsed → undetermined
-        except ImportError:
-            return None
+        if not isinstance(bound, Version):
+            return None  # bound could not be parsed → undetermined
+        saw_valid_clause = True
 
         # Each clause constrains membership: if the version fails ANY clause the
         # version is definitely outside the range (return False).
@@ -486,6 +490,9 @@ def _version_in_range(version_str: str, vulnerable_range: str) -> bool | None:
             return False
         elif op not in (">=", ">", "<=", "<", "=", "==", "!="):
             return None  # unknown operator → undetermined
+
+    if not saw_valid_clause:
+        return None
 
     # All clauses satisfied → version is within the range
     return True
@@ -726,6 +733,8 @@ def command_apply_updates(args: argparse.Namespace) -> None:
     alerts = load_alerts(Path(args.alerts_json))
     security_forces: dict[str, str] = {}
     for alert in alerts:
+        if not _is_open_alert(alert):
+            continue
         ecosystem = alert.get("dependency", {}).get("package", {}).get("ecosystem")
         dep = alert.get("dependency", {}).get("package", {}).get("name")
         patched = alert.get("security_vulnerability", {}).get("first_patched_version", {}) or {}

--- a/scripts/tests/test_manage_dependency_forces.py
+++ b/scripts/tests/test_manage_dependency_forces.py
@@ -40,6 +40,10 @@ def alert(
 
 
 class ManageDependencyForcesTest(unittest.TestCase):
+    def test_version_in_range_returns_none_for_empty_range(self):
+        self.assertIsNone(mdf._version_in_range("4.1.132.Final", ""))
+        self.assertIsNone(mdf._version_in_range("4.1.132.Final", " , , "))
+
     def test_is_safe_to_remove_rejects_open_alert(self):
         result = mdf.is_safe_to_remove(
             dep="io.netty:netty-codec-http",
@@ -50,6 +54,17 @@ class ManageDependencyForcesTest(unittest.TestCase):
             check_advisories=False,
         )
         self.assertFalse(result)
+
+    def test_open_alert_filter_only_keeps_open_alerts_for_force_additions(self):
+        alerts = [
+            alert("io.netty:netty-codec-http", "open", patched="4.1.125.Final"),
+            alert("io.netty:netty-codec-http", "fixed", patched="4.1.125.Final"),
+        ]
+
+        open_alerts = [item for item in alerts if mdf._is_open_alert(item)]
+
+        self.assertEqual(1, len(open_alerts))
+        self.assertEqual("open", open_alerts[0]["state"])
 
     def test_is_safe_to_remove_rejects_recent_historical_alert(self):
         result = mdf.is_safe_to_remove(

--- a/scripts/tests/test_manage_dependency_forces.py
+++ b/scripts/tests/test_manage_dependency_forces.py
@@ -1,0 +1,113 @@
+import sys
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import manage_dependency_forces as mdf
+
+
+def alert(
+    dep: str,
+    state: str,
+    *,
+    created_at: str = "2026-04-20T00:00:00Z",
+    updated_at: str = "2026-04-20T00:00:00Z",
+    fixed_at: str | None = None,
+    dismissed_at: str | None = None,
+    patched: str | None = None,
+) -> dict:
+    first_patched_version = {}
+    if patched is not None:
+        first_patched_version["identifier"] = patched
+    return {
+        "state": state,
+        "created_at": created_at,
+        "updated_at": updated_at,
+        "fixed_at": fixed_at,
+        "dismissed_at": dismissed_at,
+        "dependency": {
+            "package": {
+                "ecosystem": "maven",
+                "name": dep,
+            }
+        },
+        "security_vulnerability": {
+            "first_patched_version": first_patched_version,
+        },
+    }
+
+
+class ManageDependencyForcesTest(unittest.TestCase):
+    def test_is_safe_to_remove_rejects_open_alert(self):
+        result = mdf.is_safe_to_remove(
+            dep="io.netty:netty-codec-http",
+            natural_version="4.1.132.Final",
+            forced_version="4.1.125.Final",
+            alerts=[alert("io.netty:netty-codec-http", "open", patched="4.1.125.Final")],
+            cooldown_hours=168,
+            check_advisories=False,
+        )
+        self.assertFalse(result)
+
+    def test_is_safe_to_remove_rejects_recent_historical_alert(self):
+        result = mdf.is_safe_to_remove(
+            dep="io.netty:netty-codec-http",
+            natural_version="4.1.132.Final",
+            forced_version="4.1.125.Final",
+            alerts=[
+                alert(
+                    "io.netty:netty-codec-http",
+                    "fixed",
+                    fixed_at="2026-04-27T04:15:39Z",
+                    patched="4.1.125.Final",
+                )
+            ],
+            cooldown_hours=168,
+            check_advisories=False,
+            now=datetime(2026, 4, 28, 0, 0, tzinfo=timezone.utc),
+        )
+        self.assertFalse(result)
+
+    def test_is_safe_to_remove_allows_old_historical_alert_after_cooldown(self):
+        result = mdf.is_safe_to_remove(
+            dep="io.netty:netty-codec-http",
+            natural_version="4.1.132.Final",
+            forced_version="4.1.125.Final",
+            alerts=[
+                alert(
+                    "io.netty:netty-codec-http",
+                    "fixed",
+                    fixed_at="2026-04-01T00:00:00Z",
+                    patched="4.1.125.Final",
+                )
+            ],
+            cooldown_hours=168,
+            check_advisories=False,
+            now=datetime(2026, 4, 28, 0, 0, tzinfo=timezone.utc),
+        )
+        self.assertTrue(result)
+
+    def test_is_safe_to_remove_rejects_below_patched_baseline(self):
+        result = mdf.is_safe_to_remove(
+            dep="io.netty:netty-codec-http",
+            natural_version="4.1.124.Final",
+            forced_version="4.1.124.Final",
+            alerts=[
+                alert(
+                    "io.netty:netty-codec-http",
+                    "fixed",
+                    fixed_at="2026-04-01T00:00:00Z",
+                    patched="4.1.125.Final",
+                )
+            ],
+            cooldown_hours=168,
+            check_advisories=False,
+            now=datetime(2026, 4, 28, 0, 0, tzinfo=timezone.utc),
+        )
+        self.assertFalse(result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary by Sourcery

通过将含糊不清的安全公告版本范围视为不安全，以及在依赖项存在任何历史 Dependabot 警报时阻止自动移除，来收紧依赖强制移除的安全性。

Bug 修复：
- 确保在评估版本范围时，将解析失败或运算符失败视为结果不确定，而不是安全地视为在范围之外。
- 阻止对曾在任何状态下触发过 Dependabot 警报的依赖项自动移除依赖强制规则，从而避免因自动关闭的警报导致的反复震荡。

增强功能：
- 加强安全公告匹配逻辑，清晰区分版本评估结果是“在范围内”“在范围外”还是“结果不确定”。
- 更新依赖强制管理器工作流，通过 GitHub CLI 和 jq 获取所有状态、所有分页的 Dependabot 警报。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tighten dependency force removal safety by treating ambiguous advisory version ranges as unsafe and by preventing automatic removal when a dependency has any historical Dependabot alerts.

Bug Fixes:
- Ensure version range evaluation treats parse or operator failures as indeterminate rather than safely outside the range.
- Prevent automatic removal of dependency force rules for dependencies that previously triggered Dependabot alerts in any state, avoiding oscillation caused by auto-dismissed alerts.

Enhancements:
- Strengthen advisory matching logic to clearly distinguish between in-range, out-of-range, and indeterminate version evaluations.
- Update the dependency force manager workflow to fetch all Dependabot alerts across all states and pages using the GitHub CLI and jq.

</details>