### PR TITLE
fix(force-manager): fetch all dependabot alert states

### DIFF
--- a/.github/workflows/dependency-force-manager.yml
+++ b/.github/workflows/dependency-force-manager.yml
@@ -110,7 +110,7 @@ jobs:
           gh api \
             --paginate \
             -H "Accept: application/vnd.github+json" \
-            "repos/${GITHUB_REPOSITORY}/dependabot/alerts?per_page=100" \
+            "repos/${GITHUB_REPOSITORY}/dependabot/alerts?state=all&per_page=100" \
             | jq -s '[.[][]]' \
             > /tmp/dependabot-alerts.json
 


### PR DESCRIPTION
## 由 Sourcery 提供的总结

CI：
- 调整 `dependency-force-manager` 工作流中对 Dependabot 警报的 API 调用，以请求获取所有状态下的警报。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Adjust Dependabot alerts API call in the dependency-force-manager workflow to request alerts in all states.

</details>