### PR TITLE
fix(force-manager): preserve unresolved forced dependencies

### DIFF
--- a/scripts/manage_dependency_forces.py
+++ b/scripts/manage_dependency_forces.py
@@ -754,6 +754,10 @@ def command_apply_updates(args: argparse.Namespace) -> None:
             if current is None or version_key(selected) > version_key(current):
                 security_forces[dep] = selected
 
+    # This workflow owns only the managed force block. We preserve existing
+    # non-removable entries already inside that block, then merge in open-alert
+    # security forces. Non-managed force(...) lines elsewhere in the file are
+    # intentionally left untouched.
     merged_forces: dict[str, str] = {}
     for dep, version in existing_forces.items():
         if dep in removable:

--- a/scripts/manage_dependency_forces.py
+++ b/scripts/manage_dependency_forces.py
@@ -754,25 +754,22 @@ def command_apply_updates(args: argparse.Namespace) -> None:
             if current is None or version_key(selected) > version_key(current):
                 security_forces[dep] = selected
 
-    filtered: list[str] = []
-    for line in text:
-        match = re.search(r"force\((.+)\)", line)
-        if not match:
-            filtered.append(line)
+    merged_forces: dict[str, str] = {}
+    for dep, version in existing_forces.items():
+        if dep in removable:
             continue
-
-        expr = match.group(1).strip().strip("\"'")
-        dep = line_dep(expr, versions, libraries)
-        if dep and (dep in removable or dep in security_forces):
-            continue
-        filtered.append(line)
+        merged_forces[dep] = version
+    for dep, version in security_forces.items():
+        current = merged_forces.get(dep)
+        if current is None or version_key(version) > version_key(current):
+            merged_forces[dep] = version
 
     block_lines = [AUTO_FORCE_BEGIN]
-    for dep in sorted(security_forces):
-        block_lines.append(f"            force(\"{dep}:{security_forces[dep]}\")")
+    for dep in sorted(merged_forces):
+        block_lines.append(f"            force(\"{dep}:{merged_forces[dep]}\")")
     block_lines.append(AUTO_FORCE_END)
 
-    new_text = replace_managed_blocks(filtered, block_lines)
+    new_text = replace_managed_blocks(text, block_lines)
     build_path.write_text("\n".join(new_text) + "\n")
 
 

--- a/scripts/tests/test_manage_dependency_forces.py
+++ b/scripts/tests/test_manage_dependency_forces.py
@@ -1,3 +1,4 @@
+import json
 import sys
 import unittest
 from datetime import datetime, timezone
@@ -41,6 +42,39 @@ def alert(
 
 
 class ManageDependencyForcesTest(unittest.TestCase):
+    def make_apply_args(
+        self,
+        tmpdir: str,
+        *,
+        build_lines: list[str],
+        removable: list[str] | None = None,
+        alerts: list[dict] | None = None,
+        natural: dict | None = None,
+    ):
+        build_file = Path(tmpdir) / "build.gradle.kts"
+        toml_file = Path(tmpdir) / "libs.versions.toml"
+        removable_json = Path(tmpdir) / "removable.json"
+        alerts_json = Path(tmpdir) / "alerts.json"
+        natural_json = Path(tmpdir) / "natural.json"
+
+        build_file.write_text("\n".join(build_lines) + "\n")
+        toml_file.write_text("[versions]\n[libraries]\n")
+        removable_json.write_text(json.dumps(removable or [], indent=2) + "\n")
+        alerts_json.write_text(json.dumps(alerts or [], indent=2) + "\n")
+        natural_json.write_text(json.dumps(natural or {}, indent=2) + "\n")
+
+        return type(
+            "Args",
+            (),
+            {
+                "build_file": str(build_file),
+                "toml_file": str(toml_file),
+                "removable_json": str(removable_json),
+                "alerts_json": str(alerts_json),
+                "natural_json": str(natural_json),
+            },
+        )(), build_file
+
     def test_version_in_range_returns_none_for_empty_range(self):
         self.assertIsNone(mdf._version_in_range("4.1.132.Final", ""))
         self.assertIsNone(mdf._version_in_range("4.1.132.Final", " , , "))
@@ -69,51 +103,90 @@ class ManageDependencyForcesTest(unittest.TestCase):
 
     def test_apply_updates_preserves_non_removable_existing_forces_when_open_alerts_empty(self):
         with tempfile.TemporaryDirectory() as tmp:
-            build_file = Path(tmp) / "build.gradle.kts"
-            toml_file = Path(tmp) / "libs.versions.toml"
-            removable_json = Path(tmp) / "removable.json"
-            alerts_json = Path(tmp) / "alerts.json"
-            natural_json = Path(tmp) / "natural.json"
-
-            build_file.write_text(
-                "\n".join(
-                    [
-                        "buildscript {",
-                        "    configurations.all {",
-                        "        resolutionStrategy {",
-                        "            // BEGIN AUTO FORCED DEPENDENCIES (managed by workflow)",
-                        "            force(\"com.google.code.gson:gson:2.14.0\")",
-                        "            force(\"org.apache.commons:commons-lang3:3.20.0\")",
-                        "            // END AUTO FORCED DEPENDENCIES (managed by workflow)",
-                        "        }",
-                        "    }",
-                        "}",
-                    ]
-                )
-                + "\n"
+            args, build_file = self.make_apply_args(
+                tmp,
+                build_lines=[
+                    "buildscript {",
+                    "    configurations.all {",
+                    "        resolutionStrategy {",
+                    "            // BEGIN AUTO FORCED DEPENDENCIES (managed by workflow)",
+                    "            force(\"com.google.code.gson:gson:2.14.0\")",
+                    "            force(\"org.apache.commons:commons-lang3:3.20.0\")",
+                    "            // END AUTO FORCED DEPENDENCIES (managed by workflow)",
+                    "        }",
+                    "    }",
+                    "}",
+                ],
             )
-            toml_file.write_text("[versions]\n[libraries]\n")
-            removable_json.write_text("[]\n")
-            alerts_json.write_text("[]\n")
-            natural_json.write_text("{}\n")
-
-            args = type(
-                "Args",
-                (),
-                {
-                    "build_file": str(build_file),
-                    "toml_file": str(toml_file),
-                    "removable_json": str(removable_json),
-                    "alerts_json": str(alerts_json),
-                    "natural_json": str(natural_json),
-                },
-            )()
 
             mdf.command_apply_updates(args)
 
             text = build_file.read_text()
             self.assertIn('force("com.google.code.gson:gson:2.14.0")', text)
             self.assertIn('force("org.apache.commons:commons-lang3:3.20.0")', text)
+
+    def test_apply_updates_removes_only_existing_forces_marked_as_removable(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            args, build_file = self.make_apply_args(
+                tmp,
+                build_lines=[
+                    "buildscript {",
+                    "    configurations.all {",
+                    "        resolutionStrategy {",
+                    "            // BEGIN AUTO FORCED DEPENDENCIES (managed by workflow)",
+                    "            force(\"com.google.code.gson:gson:2.14.0\")",
+                    "            force(\"org.apache.commons:commons-lang3:3.20.0\")",
+                    "            // END AUTO FORCED DEPENDENCIES (managed by workflow)",
+                    "        }",
+                    "    }",
+                    "}",
+                ],
+                removable=["com.google.code.gson:gson"],
+            )
+
+            mdf.command_apply_updates(args)
+
+            text = build_file.read_text()
+            self.assertNotIn('force("com.google.code.gson:gson:2.14.0")', text)
+            self.assertIn('force("org.apache.commons:commons-lang3:3.20.0")', text)
+
+    def test_apply_updates_merges_existing_and_security_forces_preferring_highest_version(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            args, build_file = self.make_apply_args(
+                tmp,
+                build_lines=[
+                    "buildscript {",
+                    "    configurations.all {",
+                    "        resolutionStrategy {",
+                    "            // BEGIN AUTO FORCED DEPENDENCIES (managed by workflow)",
+                    "            force(\"com.google.code.gson:gson:2.14.0\")",
+                    "            force(\"com.google.guava:guava:33.6.0-jre\")",
+                    "            // END AUTO FORCED DEPENDENCIES (managed by workflow)",
+                    "        }",
+                    "    }",
+                    "}",
+                ],
+                alerts=[
+                    alert("com.google.code.gson:gson", "open", patched="2.15.0"),
+                    alert("com.google.guava:guava", "open", patched="33.5.0-jre"),
+                ],
+                natural={
+                    "com.google.code.gson:gson": {
+                        "buildscript.classpath": {"resolved": "2.15.0"},
+                    },
+                    "com.google.guava:guava": {
+                        "buildscript.classpath": {"resolved": "33.5.0-jre"},
+                    },
+                },
+            )
+
+            mdf.command_apply_updates(args)
+
+            text = build_file.read_text()
+            self.assertIn('force("com.google.code.gson:gson:2.15.0")', text)
+            self.assertNotIn('force("com.google.code.gson:gson:2.14.0")', text)
+            self.assertIn('force("com.google.guava:guava:33.6.0-jre")', text)
+            self.assertNotIn('force("com.google.guava:guava:33.5.0-jre")', text)
 
     def test_is_safe_to_remove_rejects_recent_historical_alert(self):
         result = mdf.is_safe_to_remove(

--- a/scripts/tests/test_manage_dependency_forces.py
+++ b/scripts/tests/test_manage_dependency_forces.py
@@ -2,6 +2,7 @@ import sys
 import unittest
 from datetime import datetime, timezone
 from pathlib import Path
+import tempfile
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -65,6 +66,54 @@ class ManageDependencyForcesTest(unittest.TestCase):
 
         self.assertEqual(1, len(open_alerts))
         self.assertEqual("open", open_alerts[0]["state"])
+
+    def test_apply_updates_preserves_non_removable_existing_forces_when_open_alerts_empty(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            build_file = Path(tmp) / "build.gradle.kts"
+            toml_file = Path(tmp) / "libs.versions.toml"
+            removable_json = Path(tmp) / "removable.json"
+            alerts_json = Path(tmp) / "alerts.json"
+            natural_json = Path(tmp) / "natural.json"
+
+            build_file.write_text(
+                "\n".join(
+                    [
+                        "buildscript {",
+                        "    configurations.all {",
+                        "        resolutionStrategy {",
+                        "            // BEGIN AUTO FORCED DEPENDENCIES (managed by workflow)",
+                        "            force(\"com.google.code.gson:gson:2.14.0\")",
+                        "            force(\"org.apache.commons:commons-lang3:3.20.0\")",
+                        "            // END AUTO FORCED DEPENDENCIES (managed by workflow)",
+                        "        }",
+                        "    }",
+                        "}",
+                    ]
+                )
+                + "\n"
+            )
+            toml_file.write_text("[versions]\n[libraries]\n")
+            removable_json.write_text("[]\n")
+            alerts_json.write_text("[]\n")
+            natural_json.write_text("{}\n")
+
+            args = type(
+                "Args",
+                (),
+                {
+                    "build_file": str(build_file),
+                    "toml_file": str(toml_file),
+                    "removable_json": str(removable_json),
+                    "alerts_json": str(alerts_json),
+                    "natural_json": str(natural_json),
+                },
+            )()
+
+            mdf.command_apply_updates(args)
+
+            text = build_file.read_text()
+            self.assertIn('force("com.google.code.gson:gson:2.14.0")', text)
+            self.assertIn('force("org.apache.commons:commons-lang3:3.20.0")', text)
 
     def test_is_safe_to_remove_rejects_recent_historical_alert(self):
         result = mdf.is_safe_to_remove(


### PR DESCRIPTION
## Summary by Sourcery

在应用安全强制更新时，即使没有未处理的告警，也要保留现有的不可移除的强制依赖。

Bug Fixes:
- 确保自动管理的强制阻止规则在基于未处理告警的安全强制项为空时，仍然保留现有的不可移除强制依赖，而不是将其清除。

Tests:
- 添加回归测试，验证当没有未处理告警或可移除的强制项时，现有的不可移除强制依赖仍然保留在构建文件中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Preserve existing non-removable forced dependencies when applying security force updates, even when there are no open alerts.

Bug Fixes:
- Ensure auto-managed force blocks retain existing non-removable forced dependencies instead of clearing them when open alert-derived security forces are empty.

Tests:
- Add regression test verifying that existing non-removable forced dependencies remain in the build file when there are no open alerts or removable forces.

</details>